### PR TITLE
Fixed class containment issue in "init.pp"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -63,4 +63,6 @@ class composer (
     user         => $user,
     auto_update  => $auto_update,
   }
+
+  contain "composer::install::${provider}"
 }


### PR DESCRIPTION
Because of [Class Containment](http://puppetlabs.com/blog/class-containment-puppet), the `require => Class['composer']` in `composer::project` didn't work (composer would try to run before being installed).
Note: This behaviour (`contain`) requires puppet 3.4, can use "anchor pattern" instead.
