### PR TITLE
Fixed class containment issue in "init.pp"

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -56,11 +56,15 @@ class composer (
 
   validate_re($provider, '^(wget|package)$', 'Please make sure to set $provider one of "wget" or "package".')
 
-  class { "composer::install::${provider}":
+  $install_class = "composer::install::${provider}"
+  class { $install_class:
     target_dir   => $target_dir,
     command_name => $command_name,
     package      => $package,
     user         => $user,
     auto_update  => $auto_update,
   }
+
+  anchor { 'composer::begin': before => Class[$install_class], }
+  anchor { 'composer::end':   require => Class[$install_class], }
 }


### PR DESCRIPTION
Because of [Class Containment](http://puppetlabs.com/blog/class-containment-puppet), the `require => Class['composer']` in `composer::project` didn't work (composer would try to run before being installed).
Containment implemented using [anchor pattern](http://projects.puppetlabs.com/projects/puppet/wiki/Anchor_Pattern), because already dependent on stdlib
