### PR TITLE
pin rspec-core to version that works w/ruby 1.8.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,35 +14,21 @@
 
 ---
 language: ruby
-bundler_args: --without development
+bundler_args: --without development system_tests
 sudo: false
 before_install: rm Gemfile.lock || true
-rvm:
-  - 1.8.7
-  - 1.9.3
-  - 2.0.0
-  - 2.1.0
 script: bundle exec rake test
-env:
-  - PUPPET_VERSION="~> 2.7.0"
-  - PUPPET_VERSION="~> 3.2.0"
-  - PUPPET_VERSION="~> 3.3.0"
-  - PUPPET_VERSION="~> 3.4.0"
-  - PUPPET_VERSION="~> 3.5.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.6.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes
-  - PUPPET_VERSION="~> 3.7.0" STRICT_VARIABLES=yes FUTURE_PARSER=yes
 matrix:
-  exclude:
+  include:
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 2.7"
+  - rvm: 1.8.7
+    env: PUPPET_GEM_VERSION="~> 3.0" FACTER_GEM_VERSION="~> 1.7.0"
   - rvm: 1.9.3
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_GEM_VERSION="~> 3.0"
   - rvm: 2.0.0
-    env: PUPPET_VERSION="~> 2.7.0"
+    env: PUPPET_GEM_VERSION="~> 3.0"
+  - rvm: 2.0.0
+    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
   - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 2.7.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.2.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.3.0"
-  - rvm: 2.1.0
-    env: PUPPET_VERSION="~> 3.4.0"
+    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER="yes"

--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,8 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
+  # Pinning due to bug in newer rspec with Ruby 1.8.7
+  gem 'rspec-core', '3.1.7'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
 end

--- a/Gemfile
+++ b/Gemfile
@@ -3,10 +3,11 @@ source "https://rubygems.org"
 group :test do
   gem "rake"
   gem "puppet", ENV['PUPPET_VERSION'] || '~> 3.7.0'
-  # Pinning due to bug in newer rspec with Ruby 1.8.7
-  gem 'rspec-core', '3.1.7'
+  gem "rspec-puppet", :git => 'https://github.com/rodjek/rspec-puppet.git'
   gem "puppetlabs_spec_helper"
   gem "metadata-json-lint"
+  gem "rspec-puppet-facts"
+  gem "rspec", "< 3.2.0", { "platforms" => ["ruby_18"] }
 end
 
 group :development do


### PR DESCRIPTION
this fix is analogous to
https://github.com/puppetlabs/puppetlabs-puppetdb/pull/167