### PR TITLE
Fix project install/update on newer Composer versions

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -122,13 +122,13 @@ define composer::project (
 
   exec { "composer_install_${title}":
     command => "${composer} install ${base_opts} ${install_opts}",
-    onlyif  => "${composer} install ${install_opts} --dry-run | grep -E -- '- (Install|Updat)ing '",
+    onlyif  => "${composer} install ${install_opts} --dry-run 2>&1 | grep -E -- '- (Install|Updat)ing '",
   }
 
   if $ensure == latest {
     exec { "composer_update_${title}":
       command => "${composer} update ${base_opts} ${update_opts}",
-      onlyif  => "${composer} update ${update_opts} --dry-run | grep -E -- '- (Install|Updat)ing '",
+      onlyif  => "${composer} update ${update_opts} --dry-run 2>&1 | grep -E -- '- (Install|Updat)ing '",
     }
   }
 }


### PR DESCRIPTION
Recently Composer has moved a lot of status messages from stdout
to stderr, thus we need to perform a redirect here to keep pattern
matching working.

See https://github.com/composer/composer/pull/3715

Fixes #19