### PR TITLE
Keep VCS for composer::project

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -83,7 +83,7 @@ define composer::project (
     true  => '--lock',
   }
 
-  $create_project_opts = join(flatten([$dev_opt, "--prefer-${prefer}"]), ' ')
+  $create_project_opts = join(flatten([$dev_opt, "--prefer-${prefer}", '--keep-vcs']), ' ')
   $install_opts = join(flatten([$dev_opt, $script_opt, $custom_inst_opt, "--prefer-${prefer}" ]), ' ')
   $update_opts = join(flatten([$dev_opt, $script_opt, $custom_inst_opt, "--prefer-${prefer}", $lock_opt ]), ' ')
   $user_home = $user ? {

--- a/spec/defines/project_spec.rb
+++ b/spec/defines/project_spec.rb
@@ -77,6 +77,22 @@ describe 'composer::project' do
             'cwd'     => '/srv/web/yolo'
           })}
         end
+
+        context 'Create project from source' do
+          let(:title) { 'yolo' }
+          let(:params) {{ :target => '/srv/web/yolo', :ensure => 'present', :source => 'foo/bar' }}
+
+          it { is_expected.to contain_composer__project('yolo').with({ 'ensure' => 'present'} )}
+          it { is_expected.to contain_exec('composer_create_project_yolo').with({
+            'command' => '/bin/true',
+            'onlyif'  => '/usr/local/bin/composer create-project --no-interaction --quiet --no-progress --no-dev --prefer-dist --keep-vcs foo/bar .',
+            'cwd'     => '/srv/web/yolo'
+          })}
+          it { is_expected.to contain_exec('composer_install_yolo').with({
+            'command' => '/usr/local/bin/composer install --no-interaction --quiet --no-progress --no-dev --prefer-dist',
+            'cwd'     => '/srv/web/yolo'
+          })}
+        end
       end
     end
   end


### PR DESCRIPTION
Since the execution of `composer::project` is fully automated, one cannot prevent deletion of VCS info by Composer. Thus keep it by default to be least destructive.