### PR TITLE
Output errors of "composer create-project" command

### DIFF
--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -113,9 +113,8 @@ define composer::project (
 
   if $source {
     exec { "composer_create_project_${title}":
-      # Simulate a dry run, Composer will stop with an error if e.g. the target directory is not empty
-      command => '/bin/true',
-      onlyif  => "${composer} create-project ${base_opts} ${create_project_opts} ${source} .",
+      command => "${composer} create-project ${base_opts} ${create_project_opts} ${source} .",
+      creates => "${target}/composer.json",
       before  => Exec["composer_install_${title}"],
     }
   }

--- a/spec/defines/project_spec.rb
+++ b/spec/defines/project_spec.rb
@@ -84,8 +84,8 @@ describe 'composer::project' do
 
           it { is_expected.to contain_composer__project('yolo').with({ 'ensure' => 'present'} )}
           it { is_expected.to contain_exec('composer_create_project_yolo').with({
-            'command' => '/bin/true',
-            'onlyif'  => '/usr/local/bin/composer create-project --no-interaction --quiet --no-progress --no-dev --prefer-dist --keep-vcs foo/bar .',
+            'command' => '/usr/local/bin/composer create-project --no-interaction --quiet --no-progress --no-dev --prefer-dist --keep-vcs foo/bar .',
+            'creates' => '/srv/web/yolo/composer.json',
             'cwd'     => '/srv/web/yolo'
           })}
           it { is_expected.to contain_exec('composer_install_yolo').with({


### PR DESCRIPTION
Instead of swallowing all errors by running `composer create-project` as test command, do this normally and declare that it creates a `composer.json` which can be expected as a result of this command.

This has the big advantage that all kind of errors are now shown by Puppet.