### PR TITLE
release 0.3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,7 +52,7 @@ notifications:
   email: false
 deploy:
   provider: puppetforge
-  user: Brainsware
+  user: brainsware
   password:
     secure: "Gf7Gd8iLmwWgpVm4SM/MmsrB5mqfUdK9/G03E0xcrebGAAm2UPd3xDMGPcVkrlT52+PLVFXqZAFLQQwebQN0Q2HSF/AP2aOGqCItE2wZEXuUIoqobDuL0xGAaZsnfklc3KsNFkZdCOmTHfwx0MwGcnTlMTt01ro+Jd14Glf5YY8="
   on:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,8 @@ All notable changes to this project will be documented in this file.
 Each new release typically also includes the latest modulesync defaults.
 These should not impact the functionality of the module.
 
-## Release [0.3.4](https://github.com/brainsware/puppet-composer/tree/0.3.4) (2017-03-03)
-[Full Changelog](https://github.com/brainsware/puppet-composer/compare/v0.3.0...0.3.4)
+## Release [0.3.5](https://github.com/brainsware/puppet-composer/tree/0.3.4) (2017-03-03)
+[Full Changelog](https://github.com/brainsware/puppet-composer/compare/v0.3.0...0.3.5)
 
 **Closed issues:**
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name": "Brainsware-composer",
-  "version": "0.3.5-rc0",
-  "author": "Brainsware",
+  "name": "brainsware-composer",
+  "version": "0.3.5",
+  "author": "brainsware",
   "summary": "manage PHP composer installation as well as installation and update of projects using composer",
   "license": "Apache-2.0",
   "source": "https://github.com/Brainsware/puppet-composer",


### PR DESCRIPTION
by actually, consistently, calling our user `brainsware` instead of
`Brainsware`. Usernames are normalized by the forge API *after* login…