### PR TITLE
Allow specifying a different PHP version

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,18 @@ To create a project based on another package we can use the `$source`
     }
 ```
 
+If you have multiple versions of PHP installed, you can specify which one composer should be called with by including the path to the binary.
+
+```puppet
+     # install yolo project with a different PHP version:
+     composer::project { 'yolo':
+       ensure  => 'installed',
+       target  => '/srv/web/yolo',
+       php_bin => '/usr/local/bin/php80',
+       require => Vcsrepo['/srv/web/yolo'],
+     }
+```
+
 Ensuring a composer repository is added:
 
 ```puppet

--- a/manifests/project.pp
+++ b/manifests/project.pp
@@ -45,6 +45,9 @@
 # [*user*]
 #   The owner of the project. Default: 'root'
 #
+# [*php_bin*]
+#   Specify a PHP binary to run composer with. Defaults to system default.
+#
 
 define composer::project (
   $ensure      = present,
@@ -56,6 +59,7 @@ define composer::project (
   $custom_inst = true,
   $lock        = false,
   $user        = 'root',
+  $php_bin     = '',
 ) {
   include composer
 
@@ -63,7 +67,7 @@ define composer::project (
   validate_re($prefer, '^(dist|source)$', '$prefer can only be one of source or dist. See `composer install --help`.')
   validate_bool($dev, $scripts, $custom_inst)
 
-  $composer  = "${composer::target_dir}/${composer::command_name}"
+  $composer  = strip("${php_bin} ${composer::target_dir}/${composer::command_name}")
   $base_opts = '--no-interaction --quiet --no-progress'
 
   $dev_opt = $dev? {

--- a/spec/defines/project_spec.rb
+++ b/spec/defines/project_spec.rb
@@ -93,6 +93,17 @@ describe 'composer::project' do
                                                                       'cwd' => '/srv/web/yolo')
           end
         end
+
+        context 'it should create a project with a specific php version' do
+          let(:title) { 'yolo' }
+          let(:params) { { target: '/srv/web/yolo', php_bin: '/usr/local/bin/php' } }
+
+          it { is_expected.to contain_composer__project('yolo').with('ensure' => 'present') }
+          it do
+            is_expected.to contain_exec('composer_install_yolo').with('command' => '/usr/local/bin/php /usr/local/bin/composer install --no-interaction --quiet --no-progress --no-dev --prefer-dist',
+                                                                      'cwd' => '/srv/web/yolo')
+          end
+        end
       end
     end
   end


### PR DESCRIPTION
If you have multiple PHP versions installed, this will let you specify which one should be used to run composer.